### PR TITLE
fix: updated epoch to 10

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -93,17 +93,17 @@ def main():
         train_loader=train_loader,
         test_loader=test_loader,
         device=device,
-        epochs=5,
+        epochs=10,
         lr=2e-3,
         weight_decay=1e-3,
     )
 
     # Save the best model weights
-    model_save_path = results_dir / "best_binary_model.pth"
+    model_save_path = results_dir / "best_linear_probe_model.pth"
     torch.save(model.state_dict(), model_save_path)
 
     # Save the training curves
-    plot_save_path = results_dir / "training_curves.png"
+    plot_save_path = results_dir / "training_curves_linear_probe.png"
     save_training_curves(history, plot_save_path)
 
     elapsed_seconds = time.time() - start_time


### PR DESCRIPTION
Issue #8 handled most of the code, only updated epoch = 10.
Following image and stats show the model is clearly overfitting due to freezing all of the convolutional layers and is therefore only dependent on the visual features that ResNet18 has already been trained on (not our features of different breeds in cats and dogs):

<img width="1200" height="500" alt="training_curves_linear_probe" src="https://github.com/user-attachments/assets/169a2f1d-657e-45e2-8739-a6491ff2f88f" />
 
also final accuracy:
`Epoch 10/10 | Train loss: 0.0658, Train acc: 99.2935% | Test loss: 0.3498, Test acc: 88.7708%
Best test accuracy: 89.3159%
Total runtime: 426.74 seconds`

Closes #3